### PR TITLE
More general remove_format

### DIFF
--- a/vvt_convert.py
+++ b/vvt_convert.py
@@ -29,8 +29,12 @@ def remove_format(s: str) -> str:
     
     >>> remove_format("<i>Baby, don't get hooked on me</i>")
     "Baby, don't get hooked on me"
+
+    >>> remove_format("<c.white><c.mono_sans> SO NO ONE TOLD YOU</c.mono_sans></c.white>")
+    ' SO NO ONE TOLD YOU'
+
     """
-    for matched in re.findall(r'\<\/?[a-z]\>', s):    
+    for matched in re.findall(r'\<\/?[^<>]*\>', s):
         s = s.replace(matched, '')
     return s
 


### PR DESCRIPTION
Originally `remove_format` does not handle cases such as `"<c.white><c.mono_sans> SO NO ONE TOLD YOU</c.mono_sans></c.white>"`

This patch handles it better.